### PR TITLE
Handle missing areas

### DIFF
--- a/src/areas/controllers/areas.controller.ts
+++ b/src/areas/controllers/areas.controller.ts
@@ -120,8 +120,20 @@ export class AreasController {
           const fullTeamAreas: Promise<IArea | null>[] = [];
           // get full area for each array member and push to user areas array
           for await (const teamAreaId of teamAreas) {
-            const area = this.areasService.getAreaMICROSERVICE(teamAreaId);
-            fullTeamAreas.push(area);
+            try {
+              const area = this.areasService.getAreaMICROSERVICE(teamAreaId);
+              fullTeamAreas.push(area);
+            } catch (error: any) {
+              if (error.status === 404) {
+                // area not found - delete area-team and area-template relations
+                await this.teamAreaRelationService.delete({
+                  areaId: teamAreaId,
+                });
+                await this.templateAreaRelationService.deleteMany({
+                  areaId: teamAreaId,
+                });
+              } else throw error;
+            }
           }
           const resolvedTeamAreas = await Promise.all(fullTeamAreas);
           resolvedTeamAreas.forEach((area) => {


### PR DESCRIPTION
Areas deleted in the GFW app leave legacy area-team and area-template relations for the FW app resulting in errors when trying to get all team areas. 

Delete all relations for that area if an "area not found" error is received