### PR TITLE
fix(answers): make sure only the correct answers show up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,7 @@ services:
     networks:
       - gfw-nest-network
     command: yarn test
+
   docs:
     build: .
     ports:

--- a/src/answers/services/answers.service.ts
+++ b/src/answers/services/answers.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { Answer, AnswerDocument, IAnswer } from '../models/answer.model';
-import { Model } from 'mongoose';
+import { FilterQuery, Model } from 'mongoose';
 import { InjectModel } from '@nestjs/mongoose';
 import { IUser } from '../../common/user.model';
 import { TeamDocument } from '../../teams/models/team.schema';
@@ -48,7 +48,7 @@ export class AnswersService extends BaseService<
     user: IUser;
     userTeams: TeamDocument[];
   }): Promise<IAnswer[]> {
-    let filter = {};
+    let filter: FilterQuery<AnswerDocument> = {};
     const confirmedUsers: (mongoose.Types.ObjectId | undefined)[] = [];
     // add current user to users array
     confirmedUsers.push(new mongoose.Types.ObjectId(user.id));
@@ -63,6 +63,11 @@ export class AnswersService extends BaseService<
       confirmedUsers.push(...users.map((user) => user.userId));
     }
 
+    // get all team areas
+    const teamAreasRelations = await this.teamAreaRelationService.find({
+      teamId: { $in: userTeams.map((team) => team.id) },
+    });
+
     // Admin users and owners of the report template can check all report answers
     if (
       user.role === 'ADMIN' ||
@@ -72,9 +77,28 @@ export class AnswersService extends BaseService<
         $and: [{ report: template._id }],
       };
     } else {
-      // users can see their own answers and answers their team members have made
+      // users can see their own answers and answers their team members have made as long as
+      // area is in team areas
       filter = {
-        $and: [{ report: template._id }, { user: { $in: confirmedUsers } }],
+        $or: [
+          {
+            $and: [
+              { report: template._id }, // report is from the template
+              { user: { $in: confirmedUsers } }, // user is in the teams
+              {
+                areaOfInterest: {
+                  $in: teamAreasRelations.map((relations) => relations.areaId), // report is from the team area
+                },
+              },
+            ],
+          },
+          {
+            $and: [
+              { report: template._id }, // report is from the template
+              { user: new mongoose.Types.ObjectId(user.id) }, // is user's report
+            ],
+          },
+        ],
       };
     }
     return await this.addUsernameToAnswers(await this.answerModel.find(filter));

--- a/src/answers/services/answers.service.ts
+++ b/src/answers/services/answers.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { Answer, AnswerDocument, IAnswer } from '../models/answer.model';
-import { FilterQuery, Model } from 'mongoose';
+import { Model } from 'mongoose';
 import { InjectModel } from '@nestjs/mongoose';
 import { IUser } from '../../common/user.model';
 import { TeamDocument } from '../../teams/models/team.schema';
@@ -48,7 +48,7 @@ export class AnswersService extends BaseService<
     user: IUser;
     userTeams: TeamDocument[];
   }): Promise<IAnswer[]> {
-    let filter: FilterQuery<AnswerDocument> = {};
+    let filter = {};
     const confirmedUsers: (mongoose.Types.ObjectId | undefined)[] = [];
     // add current user to users array
     confirmedUsers.push(new mongoose.Types.ObjectId(user.id));
@@ -63,11 +63,6 @@ export class AnswersService extends BaseService<
       confirmedUsers.push(...users.map((user) => user.userId));
     }
 
-    // get all team areas
-    const teamAreasRelations = await this.teamAreaRelationService.find({
-      teamId: { $in: userTeams.map((team) => team.id) },
-    });
-
     // Admin users and owners of the report template can check all report answers
     if (
       user.role === 'ADMIN' ||
@@ -77,28 +72,9 @@ export class AnswersService extends BaseService<
         $and: [{ report: template._id }],
       };
     } else {
-      // users can see their own answers and answers their team members have made as long as
-      // area is in team areas
+      // users can see their own answers and answers their team members have made
       filter = {
-        $or: [
-          {
-            $and: [
-              { report: template._id }, // report is from the template
-              { user: { $in: confirmedUsers } }, // user is in the teams
-              {
-                areaOfInterest: {
-                  $in: teamAreasRelations.map((relations) => relations.areaId), // report is from the team area
-                },
-              },
-            ],
-          },
-          {
-            $and: [
-              { report: template._id }, // report is from the template
-              { user: new mongoose.Types.ObjectId(user.id) }, // is user's report
-            ],
-          },
-        ],
+        $and: [{ report: template._id }, { user: { $in: confirmedUsers } }],
       };
     }
     return await this.addUsernameToAnswers(await this.answerModel.find(filter));
@@ -111,17 +87,28 @@ export class AnswersService extends BaseService<
     loggedUser: IUser;
     teams: TeamDocument[];
   }): Promise<IAnswer[]> {
-    let filter = {};
-    const teamMembers = await this.teamMembersService.findEveryTeamMember(
+    // get all templates
+    const publicTemplates =
+      await this.templatesService.findAllPublicTemplates();
+    const userTemplates = await this.templatesService.findAllByUserId(
       loggedUser.id,
     );
-    teamMembers.push(loggedUser.id);
+    const templates = [...publicTemplates, ...userTemplates];
 
-    filter = { user: { $in: teamMembers } };
+    const answers: IAnswer[] = [];
 
-    const answers = await this.answerModel.find(filter);
+    // get answers for each template
+    for await (const template of templates) {
+      answers.push(
+        ...(await this.getAllTemplateAnswers({
+          template,
+          user: loggedUser,
+          userTeams: teams,
+        })),
+      );
+    }
 
-    return await this.addUsernameToAnswers(answers);
+    return answers;
   }
 
   async filterAnswersByArea({

--- a/src/templates/tests/templates.e2e.spec.ts
+++ b/src/templates/tests/templates.e2e.spec.ts
@@ -514,13 +514,13 @@ describe('Templates', () => {
     });
 
     it('should return all user answers and team answers of teams user manages that are within team areas', async () => {
-      const template = await formsDbConnection
+      const defaultTemplate = await formsDbConnection
         .collection('reports')
         .insertOne({ ...constants.defaultTemplate });
-      await formsDbConnection
+      const managerTemplate = await formsDbConnection
         .collection('reports')
         .insertOne(constants.managerTemplate);
-      const template3 = await formsDbConnection
+      const userTemplate = await formsDbConnection
         .collection('reports')
         .insertOne(constants.userTemplate);
 
@@ -529,8 +529,8 @@ describe('Templates', () => {
       const managerAnswer = await formsDbConnection
         .collection('answers')
         .insertOne({
-          report: template3.insertedId,
-          reportName: 'answer 1',
+          report: managerTemplate.insertedId,
+          reportName: 'manager answer 1',
           language: 'en',
           user: new mongoose.Types.ObjectId(ROLES.MANAGER.id),
           responses: [{ name: 'question-1', value: 'test' }],
@@ -538,22 +538,22 @@ describe('Templates', () => {
       const managerAnswer2 = await formsDbConnection
         .collection('answers')
         .insertOne({
-          report: template.insertedId,
-          reportName: 'answer 1',
+          report: defaultTemplate.insertedId,
+          reportName: 'manager answer 2',
           language: 'en',
           user: new mongoose.Types.ObjectId(ROLES.MANAGER.id),
           responses: [{ name: 'question-1', value: 'test' }],
         });
       await formsDbConnection.collection('answers').insertOne({
-        report: template3.insertedId,
-        reportName: 'answer 1',
+        report: userTemplate.insertedId,
+        reportName: 'admin answer 1',
         language: 'en',
         user: new mongoose.Types.ObjectId(ROLES.ADMIN.id),
         responses: [{ name: 'question-1', value: 'test' }],
       });
       await formsDbConnection.collection('answers').insertOne({
-        report: template3.insertedId,
-        reportName: 'answer 1',
+        report: userTemplate.insertedId,
+        reportName: 'user answer 1',
         language: 'en',
         user: new mongoose.Types.ObjectId(ROLES.USER.id),
         responses: [{ name: 'question-1', value: 'test' }],
@@ -561,8 +561,8 @@ describe('Templates', () => {
       const userAnswer2 = await formsDbConnection
         .collection('answers')
         .insertOne({
-          report: template.insertedId,
-          reportName: 'answer 1',
+          report: defaultTemplate.insertedId,
+          reportName: 'user answer 2',
           areaOfInterest: new mongoose.Types.ObjectId(teamAreaId),
           language: 'en',
           user: new mongoose.Types.ObjectId(ROLES.USER.id),
@@ -596,21 +596,15 @@ describe('Templates', () => {
         .set('Authorization', 'MANAGER')
         .expect(200);
 
+      console.log(response.body.data);
+
       expect(response.body).toHaveProperty('data');
       expect(Array.isArray(response.body.data)).toBe(true);
       expect(response.body.data.length).toBe(3);
-      expect(response.body.data[0]).toHaveProperty(
-        'id',
-        managerAnswer.insertedId.toString(),
-      );
-      expect(response.body.data[1]).toHaveProperty(
-        'id',
-        managerAnswer2.insertedId.toString(),
-      );
-      expect(response.body.data[2]).toHaveProperty(
-        'id',
-        userAnswer2.insertedId.toString(),
-      );
+      const ids = response.body.data.map((answer) => answer.id);
+      expect(ids).toContain(managerAnswer.insertedId.toString());
+      expect(ids).toContain(managerAnswer2.insertedId.toString());
+      expect(ids).toContain(userAnswer2.insertedId.toString());
     });
   });
 

--- a/src/templates/tests/templates.e2e.spec.ts
+++ b/src/templates/tests/templates.e2e.spec.ts
@@ -596,8 +596,6 @@ describe('Templates', () => {
         .set('Authorization', 'MANAGER')
         .expect(200);
 
-      console.log(response.body.data);
-
       expect(response.body).toHaveProperty('data');
       expect(Array.isArray(response.body.data)).toBe(true);
       expect(response.body.data.length).toBe(3);


### PR DESCRIPTION
Update getAllAnswers endpoint to receive the correct answers.
- Answers from all user-accessible templates, both public and personal
- Answers from other users in the current user's team if the answer was made in a team area